### PR TITLE
add missing else keyword to IsPatched()

### DIFF
--- a/source/Win95Uptime.cpp
+++ b/source/Win95Uptime.cpp
@@ -36,7 +36,7 @@ bool IsPatched(){
 		RegCloseKey(temp_key);
 		is_patched=1;
 		return true;
-	}{
+	}else{
 		is_patched=0;
 		return false;
 	}


### PR DESCRIPTION
The braces suggests the else keyword should've been used here. While adding it
obviously changes the C code it doesn't actually fix a bug or even impact the
behavior of the IsPatched() function. Alternatively the braces may be removed.