### PR TITLE
Fix buffer overflow

### DIFF
--- a/source/Win95Uptime.cpp
+++ b/source/Win95Uptime.cpp
@@ -242,7 +242,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					DWORD ticks=GetTick();
 					DWORD TTL=(~ticks)+1;
 					//ticks=0xFFFFFFFF;
-					char buffer[100],numberbuffer[100],crashbuffer[100];
+					char buffer[200],numberbuffer[100],crashbuffer[100];
 					format_commas(ticks,numberbuffer);
 					format_commas(TTL,crashbuffer);
 					int days = ticks/1000/60/60/24;


### PR DESCRIPTION
The program's main output text is around 130 characters after
formatting, which is more than the size of the target buffer. As a
result, the sprintf() call ends up corrupting the stack.

This fix makes a minimal change to resolve the problem, simply by
enlarging the buffer. Obviously there are better ways to avoid such
problems more structurally (starting with snprintf etc), but in this
case a simple fix should be fine.

The effects of the overflow depend mainly on the compiler used. In
particular, this fix is necessary to make the program behave properly
when compiled with the Borland C++ command line tools.